### PR TITLE
Add support for Go modules

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,8 @@
+module github.com/DaleFarnsworth/g90updatefw
+
+go 1.14
+
+require (
+	github.com/dalefarnsworth/go-xmodem v0.0.0-20200615194141-c18b46e2d887
+	github.com/pkg/term v0.0.0-20200520122047-c3ffed290a03
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,4 @@
+github.com/dalefarnsworth/go-xmodem v0.0.0-20200615194141-c18b46e2d887 h1:KNe6N+1AEHc1AmXklkDMXdJrD9uJ93ElLHlUUHUvRxQ=
+github.com/dalefarnsworth/go-xmodem v0.0.0-20200615194141-c18b46e2d887/go.mod h1:G0sexvS0JaMD1jju3SlLvLwfKe1SGvmfvu5YfTD7mtI=
+github.com/pkg/term v0.0.0-20200520122047-c3ffed290a03 h1:pd4YKIqCB0U7O2I4gWHgEUA2mCEOENmco0l/bM957bU=
+github.com/pkg/term v0.0.0-20200520122047-c3ffed290a03/go.mod h1:Z9+Ul5bCbBKnbCvdOWbLqTHhJiYV414CURZJba6L8qA=


### PR DESCRIPTION
Hi Dale,

We spoke on the G90 mailing list - I'm also a programmer by trade who works with Go frequently. Figured I'd send a quick pull to use Go Modules so that dependencies are explicitly tracked. I can do something similar for your xmodem fork if you want. 

-Justin