### PR TITLE
docs: fix version in README, add Linux permissions section; replace deprecated ioutil

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ g106updatefw and g90updatefw are two names for the same program.
 
 Here is the output of `g90updatefw --help`:
 
-    g90updatefw version 1.5
+    g90updatefw version 1.8
 
     This program is designed to write a firmware file to a Xiegu radio.
     It can be used to update either the main unit or the display unit.
@@ -31,6 +31,29 @@ Here is the output of `g90updatefw --help`:
     and the power disconnected from the radio.
 
 The output from g106updatefw --help is extremely similar.
+
+## Linux: serial port permissions
+
+On Linux the serial port device (e.g. `/dev/ttyUSB0`) is owned by the `dialout`
+group. If you see a "permission denied" error, add your user to that group:
+
+    sudo usermod -aG dialout $USER
+
+Then log out and back in (or run `newgrp dialout` in the current shell) for the
+change to take effect.
+
+If you prefer not to modify group membership, you can create a udev rule
+instead. Create the file `/etc/udev/rules.d/50-xiegu-g90.rules` containing:
+
+    SUBSYSTEM=="tty", ATTRS{idVendor}=="10c4", ATTRS{idProduct}=="ea60", MODE="0666"
+
+Then reload udev rules:
+
+    sudo udevadm control --reload-rules && sudo udevadm trigger
+
+The vendor/product IDs above are for the CP210x USB-to-serial adapter commonly
+used with the G90 programming cable. Run `lsusb` with the cable plugged in to
+confirm the IDs for your cable if they differ.
 
 Source code and additional information about `g90updatefw` and `g106updatefw` may be found at
 [https://github.com/DaleFarnsworth/g90updatefw](

--- a/main.go
+++ b/main.go
@@ -25,7 +25,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -271,7 +270,7 @@ func main() {
 	}
 	defer serial.Close()
 
-	data, err := ioutil.ReadFile(fwFilename)
+	data, err := os.ReadFile(fwFilename)
 	if err != nil {
 		usage(err.Error())
 	}


### PR DESCRIPTION
I own a G90 and have used this tool on Linux — a couple of things I noticed:

**README: help output shows v1.5, not current v1.8**
The `--help` example in the README still references version 1.5. Updated to match the current release.

**Linux serial port permissions**
The README mentions `/dev/ttyUSB2` but doesn't explain that Linux users need to be in the `dialout` group (or have a udev rule) to access it. This is probably the most common stumbling block for new Linux users. Added a section covering both approaches, with the vendor/product IDs for the CP210x adapter used by the standard G90 programming cable.

**Replace deprecated `io/ioutil.ReadFile`**
`ioutil.ReadFile` was deprecated in Go 1.16 in favour of `os.ReadFile`. Small tidy-up with no behaviour change.

73 de 2E0FRU