### PR TITLE
ci: add GitHub Actions workflow; fix go vet findings and modernise build files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,10 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,18 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+      - run: go build ./...
+      - run: go vet ./...

--- a/Makefile
+++ b/Makefile
@@ -1,58 +1,59 @@
 FLAGS = -ldflags "-s -w"
 g106name = g106updatefw
+GOFILES = $(wildcard *.go)
 
 default: linux/amd64/g90updatefw
 
 all: darwin/amd64/g90updatefw darwin/arm64/g90updatefw linux/386/g90updatefw linux/amd64/g90updatefw linux/arm/g90updatefw linux/arm64/g90updatefw linux/ppc64/g90updatefw linux/ppc64le/g90updatefw linux/riscv64/g90updatefw linux/s390x/g90updatefw windows/386/g90updatefw.exe windows/amd64/g90updatefw.exe
 
-darwin/amd64/g90updatefw: main.go
+darwin/amd64/g90updatefw: $(GOFILES)
 	GOOS=darwin GOARCH=amd64 go build $(FLAGS) -o "$@"
 	ln -f "$@" "$(@D)"/$(g106name)
 
-darwin/arm64/g90updatefw: main.go
+darwin/arm64/g90updatefw: $(GOFILES)
 	GOOS=darwin GOARCH=arm64 go build $(FLAGS) -o "$@"
 	ln -f "$@" "$(@D)"/$(g106name)
 
-linux/386/g90updatefw: main.go
+linux/386/g90updatefw: $(GOFILES)
 	GOOS=linux GOARCH=386 go build $(FLAGS) -o "$@"
 	ln -f "$@" "$(@D)"/$(g106name)
 
-linux/amd64/g90updatefw: main.go
+linux/amd64/g90updatefw: $(GOFILES)
 	GOOS=linux GOARCH=amd64 go build $(FLAGS) -o "$@"
 	upx --brute "$@"
 	ln -f "$@" "$(@D)"/$(g106name)
 
-linux/arm/g90updatefw: main.go
+linux/arm/g90updatefw: $(GOFILES)
 	GOOS=linux GOARCH=arm go build $(FLAGS) -o "$@"
 	upx --brute "$@"
 	ln -f "$@" "$(@D)"/$(g106name)
 
-linux/arm64/g90updatefw: main.go
+linux/arm64/g90updatefw: $(GOFILES)
 	GOOS=linux GOARCH=arm64 go build $(FLAGS) -o "$@"
 	ln -f "$@" "$(@D)"/$(g106name)
 
-linux/ppc64/g90updatefw: main.go
+linux/ppc64/g90updatefw: $(GOFILES)
 	GOOS=linux GOARCH=ppc64 go build $(FLAGS) -o "$@"
 	ln -f "$@" "$(@D)"/$(g106name)
 
-linux/ppc64le/g90updatefw: main.go
+linux/ppc64le/g90updatefw: $(GOFILES)
 	GOOS=linux GOARCH=ppc64le go build $(FLAGS) -o "$@"
 	ln -f "$@" "$(@D)"/$(g106name)
 
-linux/riscv64/g90updatefw: main.go
+linux/riscv64/g90updatefw: $(GOFILES)
 	GOOS=linux GOARCH=riscv64 go build $(FLAGS) -o "$@"
 	ln -f "$@" "$(@D)"/$(g106name)
 
-linux/s390x/g90updatefw: main.go
+linux/s390x/g90updatefw: $(GOFILES)
 	GOOS=linux GOARCH=s390x go build $(FLAGS) -o "$@"
 	ln -f "$@" "$(@D)"/$(g106name)
 
-windows/386/g90updatefw.exe: main.go
+windows/386/g90updatefw.exe: $(GOFILES)
 	GOOS=windows GOARCH=386 go build $(FLAGS) -o "$@"
 	upx --brute "$@"
 	ln -f "$@" "$(@D)"/$(g106name).exe
 
-windows/amd64/g90updatefw.exe: main.go
+windows/amd64/g90updatefw.exe: $(GOFILES)
 	GOOS=windows GOARCH=amd64 go build $(FLAGS) -o "$@"
 	upx --brute "$@"
 	ln -f "$@" "$(@D)"/$(g106name).exe

--- a/main.go
+++ b/main.go
@@ -91,7 +91,6 @@ func expect(serial *Serial, expects []string) (expectIndex int) {
 		previousStr = str
 	}
 
-	panic("unreachable")
 }
 
 func expectSend(serial *Serial, expects []string, sends []string) (whichExpect string) {

--- a/serial_unix.go
+++ b/serial_unix.go
@@ -19,7 +19,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-// +build linux darwin
+//go:build linux || darwin
 
 package main
 


### PR DESCRIPTION
A follow-up to #11, addressing a few more housekeeping items found while working on the codebase.

**GitHub Actions CI**
Adds `.github/workflows/ci.yml` running `go build` and `go vet` on every push and PR to `master`. Uses `go-version-file: go.mod` so the workflow always matches the Go version declared in the module. Kept minimal — no linting, just the toolchain's own checks.

**`go vet` finding: unreachable `panic()`**
`go vet` flags the `panic("unreachable")` at the end of `expect()` as unreachable code — the preceding `for {}` loop can only exit via `return`. Removed. (This was probably added to satisfy an older compiler.)

**Build constraint syntax**
`serial_unix.go` used the old `// +build linux darwin` constraint syntax, deprecated since Go 1.17. Updated to `//go:build linux || darwin`.

**Makefile dependency fix**
All build targets listed only `main.go` as a dependency. Since `go build` compiles all `.go` files, changes to `serial_unix.go` or `serial_windows.go` would not trigger a rebuild. Replaced with `$(wildcard *.go)`.

Verified: `go build ./...` and `go vet ./...` both pass on Go 1.24.3, Linux amd64.

73 de 2E0FRU